### PR TITLE
Issue-18: textfield bottom line width fix

### DIFF
--- a/Modules/Checklist Details/ChecklistDetailsViewController.storyboard
+++ b/Modules/Checklist Details/ChecklistDetailsViewController.storyboard
@@ -88,13 +88,13 @@
                                                             <rect key="frame" x="0.0" y="0.0" width="40" height="65"/>
                                                         </imageView>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1sK-7e-Zfr" userLabel="Number of day">
-                                                            <rect key="frame" x="17.5" y="65" width="5" height="15"/>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="10"/>
+                                                            <rect key="frame" x="16.5" y="65" width="7" height="15"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="SfZ-G4-4eE">
-                                                            <rect key="frame" x="23.5" y="65" width="20" height="15"/>
+                                                            <rect key="frame" x="24.5" y="65" width="20" height="15"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="20" id="3O4-Ky-Bof"/>
                                                                 <constraint firstAttribute="height" constant="15" id="Mgv-Au-mFe"/>

--- a/Utils/BorderlessTextField.swift
+++ b/Utils/BorderlessTextField.swift
@@ -11,31 +11,41 @@ import UIKit
 
 final class BorderlessTextField: UITextField {
     
+    private var bottomLineLayer: CALayer?
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        showBottomLine()
         decorateTextField()
     }
     
     required init?(coder aDecoder: NSCoder) {
        super.init(coder: aDecoder)
         
-        showBottomLine()
         decorateTextField()
     }
     
-    private func showBottomLine() {
-        let bottomLine = CALayer()
-        bottomLine.frame = CGRect(x: 0.0, y: self.bounds.height - 1, width: self.bounds.width, height: 0.5)
-        bottomLine.backgroundColor = UIColor.lightGray.cgColor
+    override func layoutSubviews() {
+        super.layoutSubviews()
         
-        self.borderStyle = UITextField.BorderStyle.none
-        self.layer.addSublayer(bottomLine)
+        setBottomLine()
     }
     
     private func decorateTextField() {
         self.font = UIFont.systemFont(ofSize: 17, weight: .light)
+    }
+    
+    private func setBottomLine() {
+        self.bottomLineLayer?.removeFromSuperlayer()
+        
+        let bottomLine = CALayer()
+        bottomLine.frame = CGRect(x: 0.0, y: self.frame.height - 1, width: self.frame.width, height: 0.5)
+        bottomLine.backgroundColor = UIColor.lightGray.cgColor
+        
+        self.borderStyle = UITextField.BorderStyle.none
+        self.layer.addSublayer(bottomLine)
+        
+        self.bottomLineLayer = bottomLine
     }
     
 }


### PR DESCRIPTION
### Issue Link :information_source:
https://github.com/Klushechka/ChecklistCreator/issues/18

### Explanation :book:
Unfortunately textfield bottom line (layer) width doesn't automatically update when textfield width updates. It should be updated every time when the textField frame changes.

So I've moved setting bottom line to the method when a new textfield frame is already updated. 

I've also added a minor change to the day number font size on Checklist Details screen. 